### PR TITLE
Prevent platform-specific errors from c_char type mismatch

### DIFF
--- a/src/voption.rs
+++ b/src/voption.rs
@@ -48,8 +48,8 @@ pub fn call_option_string(
 }
 
 pub(crate) fn call_option_string_(
-    operation: *const i8,
-    option_string: *mut i8,
+    operation: *const std::os::raw::c_char,
+    option_string: *mut std::os::raw::c_char,
     option: VOption,
 ) -> std::os::raw::c_int {
     unsafe {


### PR DESCRIPTION
When compiling on Linux, I had to make these changes after running into compile errors, presumably because c_char means u8 instead of i8 on that platform. I'm not familiar with C, but it seems to have worked completely perfectly, as my project that uses rs_vips has behaved no differently than the Windows build in any places, and it seems to be consistent with broader rs_vips because the places that call `call_option_string_` all give it c_chars.